### PR TITLE
Fix Homepage 404

### DIFF
--- a/home/home.js
+++ b/home/home.js
@@ -1,5 +1,5 @@
-document.getElementById("embed").innerHTML = '<iframe src="../#26498205" style="width: 250px; min-height: 538.5px; border: none;"></iframe>';
-document.getElementById("Ecode").innerHTML = '<iframe src="https://accio1.github.io/SSE/#26498205" style="width: 250px; min-height: 538.5px; border: none;"></iframe>';
+document.getElementById("embed").innerHTML = '<iframe src="../#FEATURED" style="width: 250px; min-height: 538.5px; border: none;"></iframe>';
+document.getElementById("Ecode").innerHTML = '<iframe src="https://accio1.github.io/SSE/#FEATURED" style="width: 250px; min-height: 538.5px; border: none;"></iframe>';
 	
 function preview() {
 	var P_StudioID;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="stylesheet.css">
 	<link rel="shortcut icon" type="image/png" href="favicon.png">
 </head>
-<body style="margin:0">
+<body style="margin:0" onload="calculate()">
 	<div class="container">
 		<h2 id="title">Loading...</h2>
 		<p id="error"></p>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,3 @@
-setTimeout(display, 500)
-
 if (window.location.hash === "" || window.location.hash === "#") {
 	window.location.replace("home");
 	} 
@@ -13,22 +11,29 @@ var pull = new XMLHttpRequest()
 var Oldsid = location.hash
 var sid = Oldsid.substring(1).toUpperCase();
 	
-if (sid=="SDS" || sid=="FEATURED") {
-	pull.open("GET", "https://cors-anywhere.herokuapp.com/api.scratch.mit.edu/proxy/featured");
-	pull.send();
-	pull.onreadystatechange = function() {
-  		if (pull.readyState === 4 && pull.status === 200) {
-   			pulldone = JSON.parse(pull.responseText);
-			if (sid == "SDS") {
-				sid = pulldone.scratch_design_studio[0].gallery_id;
-			}
-			else if (sid == "FEATURED") {
-				sid = pulldone.community_featured_studios[0].id
+function calculate(){
+	if (sid=="SDS" || sid=="FEATURED") {
+		pull.open("GET", "https://cors-anywhere.herokuapp.com/api.scratch.mit.edu/proxy/featured");
+		pull.send();
+		pull.onreadystatechange = function() {
+  			if (pull.readyState === 4 && pull.status === 200) {
+   				pulldone = JSON.parse(pull.responseText);
+				if (sid == "SDS") {
+					sid = pulldone.scratch_design_studio[0].gallery_id;
+					display()
+				}
+				else if (sid == "FEATURED") {
+					sid = pulldone.community_featured_studios[0].id
+					display()
+				}
 			}
 		}
 	}
+	else {
+		display()
+	}
 }
-	
+
 function display(){
 	var pull = new XMLHttpRequest()
 	pull.open("GET", `https://cors-anywhere.herokuapp.com/api.scratch.mit.edu/studios/${sid}`);


### PR DESCRIPTION
Closes #6 

Rework JavaScript so that the studio id is always calculated before the studio is displayed. This will prevent 404's from happening when the studio ID is set to SDS or Featured